### PR TITLE
Fix API server foreground service lifecycle

### DIFF
--- a/lib/services/local_api_server_service.dart
+++ b/lib/services/local_api_server_service.dart
@@ -7,6 +7,7 @@ import 'package:llamadart/llamadart.dart';
 
 import 'chat_storage_service.dart';
 import 'llm_service.dart';
+import 'wakelock_service.dart';
 
 class LocalApiServerService extends GetxService {
   static const defaultHost = '127.0.0.1';
@@ -68,6 +69,11 @@ class LocalApiServerService extends GetxService {
       _storage.localApiServerEnabled = true;
       isRunning.value = true;
 
+      try {
+        final wakelockService = Get.find<WakelockService>();
+        await wakelockService.enableForInference();
+      } catch (_) {}
+
       unawaited(
         _server!
             .listen(
@@ -99,6 +105,10 @@ class LocalApiServerService extends GetxService {
     if (persist) {
       _storage.localApiServerEnabled = false;
     }
+    try {
+      final wakelockService = Get.find<WakelockService>();
+      await wakelockService.disable();
+    } catch (_) {}
   }
 
   Future<void> setPort(int nextPort) async {
@@ -577,8 +587,8 @@ class LocalApiServerService extends GetxService {
   String _completionId() => 'chatcmpl-${DateTime.now().microsecondsSinceEpoch}';
 
   @override
-  void onClose() {
-    stop();
+  Future<void> onClose() async {
+    await stop();
     super.onClose();
   }
 }


### PR DESCRIPTION
## Problem

The local API server does not activate the Android foreground service when started. This causes it to be killed by the OS when the user switches to another app, making the "serve the local API to other apps" use case (already mentioned in the battery optimisation prompt) non-functional in practice.

The `onClose()` method also calls `stop()` without awaiting it — since `stop()` is `async`, the `HttpServer` may not finish closing before the process tears down.

## Changes

- `start()`: call `WakelockService.enableForInference()` after the server binds successfully, consistent with how model loading already keeps the process alive
- `stop()`: call `WakelockService.disable()` when the server shuts down
- `onClose()`: make `async` and `await stop()` so the server closes cleanly on service disposal

The wakelock calls are wrapped in a try/catch so that environments where `WakelockService` is unavailable degrade gracefully.

## Testing

Start the API server, switch to another app (or lock the screen), verify the server remains reachable at `localhost:4891`.